### PR TITLE
docs: 代码 v3 榜单档位/状态底色与说明优化

### DIFF
--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -2086,12 +2086,14 @@ function renderTableNote() {
     ["c", t("codev3Note.gradeC")],
     ["d", t("codev3Note.gradeD")],
     ["failed", t("codev3Note.failed")],
+    ["pass", t("codev3Note.pass")],
+    ["pending", t("codev3Note.pending")],
   ];
   const gradeList = gradeItems
     .map(
       ([tier, text]) =>
         `<li><span class="grade-chip grade-chip--${tier}">${
-          tier === "failed" ? "Failed" : tier.toUpperCase()
+          tier.length === 1 ? tier.toUpperCase() : tier[0].toUpperCase() + tier.slice(1)
         }</span><span>${text}</span></li>`
     )
     .join("");
@@ -2159,11 +2161,17 @@ function updateMeta(dataset = null) {
       ? t("meta.records.withTotal", { count: filtered, total })
       : t("meta.records.single", { count: filtered });
 
+  const codev3FormatNote =
+    dataset.category === "code_v3"
+      ? `<span class="meta-note">${t("meta.codev3CellFormat")}</span>`
+      : "";
+
   meta.innerHTML = `
     <span>${t("meta.category", { label: categoryLabel })}</span>
     <span>${t("meta.dataset", { label: datasetLabel })}</span>
     <span>${recordsLabel}</span>
     <span>${t("meta.datasetCount", { count: reportCount })}</span>
+    ${codev3FormatNote}
   `;
   meta.classList.add("active");
 }

--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -411,6 +411,7 @@ const elements = {
   countryFilter: document.getElementById("countryFilter"),
   searchInput: document.getElementById("searchInput"),
   tableContainer: document.getElementById("tableContainer"),
+  tableNote: document.getElementById("tableNote"),
   datasetMeta: document.getElementById("datasetMeta"),
   categoryLabel: document.getElementById("categoryLabel"),
   datasetLabel: document.getElementById("datasetLabel"),
@@ -1451,6 +1452,23 @@ function getCodeV3StatusClass(value) {
   return null;
 }
 
+function getCodeV3GradeCellClass(value) {
+  if (state.currentCategory !== "code_v3") return null;
+  const parsed = parseCodeV3RankGrade(value);
+  if (!parsed) return null;
+  return `codev3-cell--${parsed.gradeBase.toLowerCase()}`;
+}
+
+function getCodeV3CellBackgroundClass(value) {
+  if (state.currentCategory !== "code_v3") return null;
+  const normalized = String(value ?? "").trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized === "pass") return "codev3-cell--pass";
+  if (normalized.startsWith("failed")) return "codev3-cell--failed";
+  if (normalized.startsWith("pending")) return "codev3-cell--pending";
+  return null;
+}
+
 function parseCodeV3RankGrade(value) {
   if (state.currentCategory !== "code_v3") return null;
   const normalized = String(value ?? "").trim();
@@ -1604,6 +1622,11 @@ function appendStructuredMetric(rowElement, metric) {
   item.className = "mobile-card-row-metric";
   if (metric.tone === "muted") {
     item.classList.add("mobile-card-row-metric--muted");
+  }
+  const cellClass =
+    getCodeV3GradeCellClass(metric.value) || getCodeV3CellBackgroundClass(metric.value);
+  if (cellClass) {
+    item.classList.add(cellClass);
   }
 
   const label = document.createElement("span");
@@ -1858,6 +1881,7 @@ function renderTable() {
   container.innerHTML = "";
   container.classList.remove("mobile-cards");
   container.classList.remove("table-container--codev3");
+  renderTableNote();
 
   if (!state.headers.length) {
     showPlaceholder(t("placeholders.selectDataset"));
@@ -1945,6 +1969,14 @@ function renderTable() {
       if (statusClass) {
         td.classList.add(...statusClass.split(" "));
       }
+      const gradeCellClass = getCodeV3GradeCellClass(cell);
+      if (gradeCellClass) {
+        td.classList.add(gradeCellClass);
+      }
+      const cellBackgroundClass = getCodeV3CellBackgroundClass(cell);
+      if (cellBackgroundClass) {
+        td.classList.add(cellBackgroundClass);
+      }
       appendCodeV3ValueContent(td, displayValue);
 
       if (columnIndex === modelColumnIndex && row.isThink) {
@@ -2026,6 +2058,61 @@ function renderTable() {
 
   table.appendChild(tbody);
   container.appendChild(table);
+}
+
+function renderTableNote() {
+  const note = elements.tableNote;
+  if (!note) return;
+
+  const isCodeV3 = state.currentCategory === "code_v3" && state.headers.length > 0;
+  const hasNewMode = isCodeV3 && state.headers.some((header) => /\(H\)|\(I\)/.test(header));
+  const hasGradeValues =
+    isCodeV3 &&
+    state.rows.some((row) =>
+      row.cells.some((cell) => /^.+?\/[ABCD][+-]?$/i.test(String(cell ?? "").trim()))
+    );
+
+  if (!hasNewMode && !hasGradeValues) {
+    note.hidden = true;
+    note.innerHTML = "";
+    return;
+  }
+
+  note.hidden = false;
+
+  const gradeItems = [
+    ["a", t("codev3Note.gradeA")],
+    ["b", t("codev3Note.gradeB")],
+    ["c", t("codev3Note.gradeC")],
+    ["d", t("codev3Note.gradeD")],
+    ["failed", t("codev3Note.failed")],
+  ];
+  const gradeList = gradeItems
+    .map(
+      ([tier, text]) =>
+        `<li><span class="grade-chip grade-chip--${tier}">${
+          tier === "failed" ? "Failed" : tier.toUpperCase()
+        }</span><span>${text}</span></li>`
+    )
+    .join("");
+
+  const monthly = hasNewMode
+    ? [
+        `<h3>${t("codev3Note.monthlyTitle")}</h3>`,
+        `<p>${t("codev3Note.monthlyP1")}</p>`,
+        `<p>${t("codev3Note.monthlyP2")}</p>`,
+        `<p>${t("codev3Note.monthlyP3")}</p>`,
+        `<p>${t("codev3Note.monthlyP4")}</p>`,
+        `<p>${t("codev3Note.monthlyP5")}</p>`,
+      ].join("")
+    : "";
+
+  note.innerHTML = [
+    `<h3>${t("codev3Note.title")}</h3>`,
+    `<ul class="grade-list">${gradeList}</ul>`,
+    `<p>${t("codev3Note.halfGrade")}</p>`,
+    monthly,
+  ].join("");
 }
 
 function toggleSort(columnIndex) {

--- a/docs/assets/i18n.js
+++ b/docs/assets/i18n.js
@@ -552,14 +552,22 @@ const TRANSLATIONS = {
     "zh-CN": "知识或方法论不够，即便有人帮助，也无法完成任务。",
     "en-US": "— lacks the knowledge or methodology to complete the task even with help.",
   },
+  "codev3Note.pass": {
+    "zh-CN": "：推测模型可顺利完成测试。",
+    "en-US": ": expected to complete the test successfully.",
+  },
+  "codev3Note.pending": {
+    "zh-CN": "：正在测试中。",
+    "en-US": ": testing in progress.",
+  },
   "codev3Note.halfGrade": {
     "zh-CN": "同档位中，只有少数轮次出现问题，大部分情况表现良好时，会升半档，用 B+、C+ 来表示。",
     "en-US":
       "Within the same grade, when only a few rounds have issues and the model performs well most of the time, it is upgraded by a half grade, denoted as B+ or C+.",
   },
   "codev3Note.monthlyTitle": {
-    "zh-CN": "本月方法说明",
-    "en-US": "This Month's Methodology",
+    "zh-CN": "2026-07 月榜方法说明",
+    "en-US": "2026-07 Monthly Methodology",
   },
   "codev3Note.monthlyP1": {
     "zh-CN":
@@ -589,6 +597,10 @@ const TRANSLATIONS = {
     "zh-CN": "现有的 C 和 D 项目对头部模型已饱和，下月起将不再使用。其中 C 项目也会升级为 2 轮版本。D 项目已被 I 项目取代。",
     "en-US":
       "The current C and D projects have saturated for top models and will be retired starting next month. C will be upgraded to a 2-round version, and D has been replaced by I.",
+  },
+  "meta.codev3CellFormat": {
+    "zh-CN": "1/A 代表扣分数/档位",
+    "en-US": "1/A means deduction points / grade",
   },
 };
 

--- a/docs/assets/i18n.js
+++ b/docs/assets/i18n.js
@@ -526,6 +526,70 @@ const TRANSLATIONS = {
     "zh-CN": "当月得分",
     "en-US": "Score",
   },
+  "codev3Note.title": {
+    "zh-CN": "档位说明",
+    "en-US": "Grade Guide",
+  },
+  "codev3Note.gradeA": {
+    "zh-CN": "档：几乎不犯错，只犯微小的 UI、交互类错误。",
+    "en-US": "Grade: almost never makes mistakes — only minor UI or interaction errors.",
+  },
+  "codev3Note.gradeB": {
+    "zh-CN": "档：大概率会错，但只要描述错误，都可以在不超过 2 轮内修复。",
+    "en-US": "Grade: likely to make mistakes, but any described error can be fixed within 2 rounds.",
+  },
+  "codev3Note.gradeC": {
+    "zh-CN": "档：大概率错，但需要交互更多轮，模型能自主推进修复，无需人工提供辅助。",
+    "en-US":
+      "Grade: likely to make mistakes and needs more interaction rounds, but the model drives fixes autonomously without human assistance.",
+  },
+  "codev3Note.gradeD": {
+    "zh-CN": "档：必须有人工提供大量 log、视觉描述，协助操作等才能修复问题。",
+    "en-US":
+      "Grade: requires the human to provide extensive logs, visual descriptions, and hands-on assistance to fix issues.",
+  },
+  "codev3Note.failed": {
+    "zh-CN": "知识或方法论不够，即便有人帮助，也无法完成任务。",
+    "en-US": "— lacks the knowledge or methodology to complete the task even with help.",
+  },
+  "codev3Note.halfGrade": {
+    "zh-CN": "同档位中，只有少数轮次出现问题，大部分情况表现良好时，会升半档，用 B+、C+ 来表示。",
+    "en-US":
+      "Within the same grade, when only a few rounds have issues and the model performs well most of the time, it is upgraded by a half grade, denoted as B+ or C+.",
+  },
+  "codev3Note.monthlyTitle": {
+    "zh-CN": "本月方法说明",
+    "en-US": "This Month's Methodology",
+  },
+  "codev3Note.monthlyP1": {
+    "zh-CN":
+      "本月主要尝试优化测试效率。原先 C 到 G 5 个项目都是多轮项目，通过中途多次重启来观察模型面对存量代码，如何有效发起探索。随着模型能力提升，存量探索已大体不是问题。观察二三梯队模型的错误情况，通常也不是来自存量探索不充分，而是对新需求把握不好。所以得到一个洞察：轮次可以压缩，不必再把完成工程拆成 10 轮。",
+    "en-US":
+      "This month we focused on improving testing efficiency. Projects C through G (5 projects) were previously all multi-round, restarting midway several times to observe how models effectively initiate exploration when facing existing code. As model capabilities improve, exploring existing code is largely no longer a problem. Errors from second- and third-tier models usually stem not from insufficient exploration of existing code, but from failing to grasp new requirements. This led to the insight that rounds can be compressed — no need to split a full project into 10 rounds.",
+  },
+  "codev3Note.monthlyP2": {
+    "zh-CN":
+      "因此新的 H 和 I 项目实践了新的模式，只保留 2 轮：第一轮让模型从 0 开发完整需求；第二轮重启后修复所有 Bug。从结果来看，这样的模式也能很好拉开各个模型差距。尤其按档位来看，好的模型依然可以不错或少错，错误能一次改好；下位模型则也会反复出错，Debug 效率低下。",
+    "en-US":
+      "The new H and I projects therefore follow a new pattern with only 2 rounds: round 1 lets the model build the complete requirement from scratch; round 2 restarts and fixes all bugs. As the results show, this pattern still separates the models well. By grade, good models still make few or no mistakes and fix errors in one pass, while lower-tier models repeatedly make mistakes and debug inefficiently.",
+  },
+  "codev3Note.monthlyP3": {
+    "zh-CN":
+      "H 项目以考察模型的 3D 建模和审美为主，但建模复杂度不高，所以叫 Simple Model。Opus-5、Kimi K3 这类在建模方面有良好口碑的模型，在 H 项目上游刃有余，输出的美观度远超其他模型。尤其 Opus-5 输出的模型材质在精度方面达到了前所未有的高度，甚至超过 Fable-5。当然最终成本也超过 Fable。而下位 C 档模型虽然整体更差，但也有一定可用性，如果是用户提供材质，不要让模型自绘，则无疑会极大提升这类模型的可用性。",
+    "en-US":
+      "The H project mainly tests 3D modeling and aesthetics, but the modeling complexity is low, hence the name Simple Model. Models with a strong reputation in modeling, such as Opus-5 and Kimi K3, excel in H, with output aesthetics far beyond other models. Opus-5's material precision in particular reached an unprecedented level, even surpassing Fable-5 — at a higher final cost than Fable. Lower C-tier models are worse overall but still somewhat usable; if the user provides the materials instead of letting the model draw them itself, their usability improves dramatically.",
+  },
+  "codev3Note.monthlyP4": {
+    "zh-CN":
+      "I 项目是原先 D 项目的升级版本，更换了底层技术栈，但功能基本不变。各模型得分如果跟 D 对照则能看到非常明显的差异。头部模型基本不受影响，无论是拆功能还是完整功能一次性写，最终交付成品是基本相当。甚至 Opus、Fable 这类模型，因为一次拿到了更多需求细节，反而有更多合理发挥空间，能充分考虑用户真实诉求，做出更好的成品，UI 设计、服务端设计等可以做得更妥善。国产 Kimi K3 也完全不弱。而下位模型则普遍差于 D 项目，内容合并后，反而无法细致遵守每一条规则和约束。这也说明，随着模型能力提升，一次性讲清楚需求更为重要。",
+    "en-US":
+      "The I project is an upgraded version of the former D project — the underlying tech stack changed, but the features are basically the same. Comparing scores with D shows a very clear difference. Top models are basically unaffected: whether features are split up or written all at once, the final deliverables are roughly equivalent. Models like Opus and Fable even gain more room to play because they receive more requirement detail at once — they can fully consider the user's real needs and deliver better results, with more careful UI and server-side design. Domestic model Kimi K3 is no slouch either. Lower-tier models, however, generally do worse than in D: once the content is merged, they can no longer follow every rule and constraint meticulously. This also shows that as models improve, stating requirements completely up front matters more.",
+  },
+  "codev3Note.monthlyP5": {
+    "zh-CN": "现有的 C 和 D 项目对头部模型已饱和，下月起将不再使用。其中 C 项目也会升级为 2 轮版本。D 项目已被 I 项目取代。",
+    "en-US":
+      "The current C and D projects have saturated for top models and will be retired starting next month. C will be upgraded to a 2-round version, and D has been replaced by I.",
+  },
 };
 
 const listeners = new Set();

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -57,11 +57,18 @@
   --color-card-codev3-secondary-border: #e0ddd2;
 
   --color-grade-a: #2f6b46;
-  --color-grade-b: #8a6d1f;
-  --color-grade-c: #a2543a;
-  --color-grade-d: #8f3126;
+  --color-grade-b: #96740b;
+  --color-grade-c: #c25a1d;
+  --color-grade-d: #b83a24;
+  --color-grade-bg-a: rgba(27, 142, 76, 0.16);
+  --color-grade-bg-b: rgba(226, 178, 0, 0.26);
+  --color-grade-bg-c: rgba(240, 125, 20, 0.26);
+  --color-grade-bg-d: rgba(230, 65, 35, 0.34);
+  --color-status-bg-pass: rgba(27, 142, 76, 0.16);
+  --color-status-bg-failed: rgba(215, 25, 25, 0.4);
+  --color-status-bg-pending: rgba(111, 108, 101, 0.13);
   --color-status-pending: #6f6c65;
-  --color-status-failed: #8f3126;
+  --color-status-failed: #c62828;
   --color-status-skip: #a09c90;
   --color-family-dot: #d97c2b;
 
@@ -118,11 +125,18 @@
   --color-card-codev3-secondary-border: #403e35;
 
   --color-grade-a: #7fb98f;
-  --color-grade-b: #c9a94f;
-  --color-grade-c: #cf8a6f;
-  --color-grade-d: #d97f70;
+  --color-grade-b: #e6bf4a;
+  --color-grade-c: #f29a52;
+  --color-grade-d: #f28e72;
+  --color-grade-bg-a: rgba(96, 196, 132, 0.26);
+  --color-grade-bg-b: rgba(255, 208, 80, 0.3);
+  --color-grade-bg-c: rgba(255, 148, 52, 0.3);
+  --color-grade-bg-d: rgba(255, 100, 55, 0.35);
+  --color-status-bg-pass: rgba(96, 196, 132, 0.26);
+  --color-status-bg-failed: rgba(255, 64, 64, 0.3);
+  --color-status-bg-pending: rgba(160, 156, 144, 0.2);
   --color-status-pending: #a09c90;
-  --color-status-failed: #d97f70;
+  --color-status-failed: #ff7a6e;
   --color-status-skip: #6f6c65;
   --color-family-dot: #e89a52;
 
@@ -181,11 +195,18 @@
     --color-card-codev3-secondary-bg: #26251f;
     --color-card-codev3-secondary-border: #403e35;
     --color-grade-a: #7fb98f;
-    --color-grade-b: #c9a94f;
-    --color-grade-c: #cf8a6f;
-    --color-grade-d: #d97f70;
+    --color-grade-b: #e6bf4a;
+    --color-grade-c: #f29a52;
+    --color-grade-d: #f28e72;
+    --color-grade-bg-a: rgba(96, 196, 132, 0.26);
+    --color-grade-bg-b: rgba(255, 208, 80, 0.3);
+    --color-grade-bg-c: rgba(255, 148, 52, 0.3);
+    --color-grade-bg-d: rgba(255, 100, 55, 0.35);
+    --color-status-bg-pass: rgba(96, 196, 132, 0.26);
+    --color-status-bg-failed: rgba(255, 64, 64, 0.3);
+    --color-status-bg-pending: rgba(160, 156, 144, 0.2);
     --color-status-pending: #a09c90;
-    --color-status-failed: #d97f70;
+    --color-status-failed: #ff7a6e;
     --color-status-skip: #6f6c65;
     --color-family-dot: #e89a52;
     --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.3);
@@ -826,6 +847,147 @@ main {
 
 .codev3-grade--d {
   color: var(--color-grade-d);
+}
+
+/* 档位单元格整格底色 */
+.codev3-cell--a {
+  background-color: var(--color-grade-bg-a);
+}
+
+.codev3-cell--b {
+  background-color: var(--color-grade-bg-b);
+}
+
+.codev3-cell--c {
+  background-color: var(--color-grade-bg-c);
+}
+
+.codev3-cell--d {
+  background-color: var(--color-grade-bg-d);
+}
+
+.codev3-cell--pass {
+  background-color: var(--color-status-bg-pass);
+}
+
+.codev3-cell--failed {
+  background-color: var(--color-status-bg-failed);
+}
+
+.codev3-cell--pending {
+  background-color: var(--color-status-bg-pending);
+}
+
+/* 移动端指标块整块底色（覆盖卡片自带底色） */
+.mobile-card-row-metric.codev3-cell--a {
+  background-color: var(--color-grade-bg-a);
+}
+
+.mobile-card-row-metric.codev3-cell--b {
+  background-color: var(--color-grade-bg-b);
+}
+
+.mobile-card-row-metric.codev3-cell--c {
+  background-color: var(--color-grade-bg-c);
+}
+
+.mobile-card-row-metric.codev3-cell--d {
+  background-color: var(--color-grade-bg-d);
+}
+
+.mobile-card-row-metric.codev3-cell--pass {
+  background-color: var(--color-status-bg-pass);
+}
+
+.mobile-card-row-metric.codev3-cell--failed {
+  background-color: var(--color-status-bg-failed);
+}
+
+.mobile-card-row-metric.codev3-cell--pending {
+  background-color: var(--color-status-bg-pending);
+}
+
+/* ---------------- 表格底部说明（档位说明） ---------------- */
+
+.table-note {
+  margin-top: 14px;
+  padding: 14px 16px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-panel);
+}
+
+.table-note h3 {
+  margin: 0 0 8px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--color-text);
+}
+
+.table-note h3:not(:first-child) {
+  margin-top: 18px;
+}
+
+.table-note ul.grade-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.table-note li {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 6px 0;
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--color-muted);
+}
+
+.table-note p {
+  margin: 8px 0 0;
+  font-size: 13px;
+  line-height: 1.8;
+  color: var(--color-muted);
+}
+
+.table-note .grade-chip {
+  flex: none;
+  display: inline-block;
+  min-width: 26px;
+  margin-top: 2px;
+  padding: 0 5px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.6;
+  text-align: center;
+}
+
+.table-note .grade-chip--a {
+  color: var(--color-grade-a);
+  background-color: var(--color-grade-bg-a);
+}
+
+.table-note .grade-chip--b {
+  color: var(--color-grade-b);
+  background-color: var(--color-grade-bg-b);
+}
+
+.table-note .grade-chip--c {
+  color: var(--color-grade-c);
+  background-color: var(--color-grade-bg-c);
+}
+
+.table-note .grade-chip--d {
+  color: var(--color-grade-d);
+  background-color: var(--color-grade-bg-d);
+}
+
+.table-note .grade-chip--failed {
+  color: var(--color-status-failed);
+  background-color: var(--color-status-bg-failed);
 }
 
 .mobile-card-note {

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -22,8 +22,8 @@
   --color-disabled-bg: #efede7;
   --color-table-head: #ffffff;
   --color-row-even: #ffffff;
-  --color-row-hover: rgba(31, 78, 121, 0.055);
-  --color-row-hover-solid: #f3f5f8;
+  --color-row-hover: rgba(31, 78, 121, 0.1);
+  --color-row-hover-solid: #e8edf4;
   --color-badge-bg: transparent;
   --color-button-focus: rgba(31, 78, 121, 0.16);
   --color-control-focus: rgba(31, 78, 121, 0.14);
@@ -56,16 +56,16 @@
   --color-card-codev3-secondary-bg: #f8f7f3;
   --color-card-codev3-secondary-border: #e0ddd2;
 
-  --color-grade-a: #2f6b46;
+  --color-grade-a: #0d2819;
   --color-grade-b: #96740b;
   --color-grade-c: #c25a1d;
   --color-grade-d: #b83a24;
-  --color-grade-bg-a: rgba(27, 142, 76, 0.16);
-  --color-grade-bg-b: rgba(226, 178, 0, 0.26);
-  --color-grade-bg-c: rgba(240, 125, 20, 0.26);
-  --color-grade-bg-d: rgba(230, 65, 35, 0.34);
-  --color-status-bg-pass: rgba(27, 142, 76, 0.16);
-  --color-status-bg-failed: rgba(215, 25, 25, 0.4);
+  --color-grade-bg-a: rgba(12, 122, 64, 0.58);
+  --color-grade-bg-b: rgba(195, 145, 0, 0.38);
+  --color-grade-bg-c: rgba(235, 130, 30, 0.26);
+  --color-grade-bg-d: rgba(225, 85, 55, 0.24);
+  --color-status-bg-pass: rgba(27, 142, 76, 0.15);
+  --color-status-bg-failed: rgba(230, 105, 95, 0.2);
   --color-status-bg-pending: rgba(111, 108, 101, 0.13);
   --color-status-pending: #6f6c65;
   --color-status-failed: #c62828;
@@ -90,8 +90,8 @@
   --color-disabled-bg: #2a2924;
   --color-table-head: #201f1b;
   --color-row-even: #201f1b;
-  --color-row-hover: rgba(147, 184, 220, 0.08);
-  --color-row-hover-solid: #292b2a;
+  --color-row-hover: rgba(147, 184, 220, 0.14);
+  --color-row-hover-solid: #333a42;
   --color-badge-bg: transparent;
   --color-button-focus: rgba(147, 184, 220, 0.22);
   --color-control-focus: rgba(147, 184, 220, 0.18);
@@ -124,16 +124,16 @@
   --color-card-codev3-secondary-bg: #26251f;
   --color-card-codev3-secondary-border: #403e35;
 
-  --color-grade-a: #7fb98f;
+  --color-grade-a: #e8f6ee;
   --color-grade-b: #e6bf4a;
   --color-grade-c: #f29a52;
   --color-grade-d: #f28e72;
-  --color-grade-bg-a: rgba(96, 196, 132, 0.26);
-  --color-grade-bg-b: rgba(255, 208, 80, 0.3);
-  --color-grade-bg-c: rgba(255, 148, 52, 0.3);
-  --color-grade-bg-d: rgba(255, 100, 55, 0.35);
-  --color-status-bg-pass: rgba(96, 196, 132, 0.26);
-  --color-status-bg-failed: rgba(255, 64, 64, 0.3);
+  --color-grade-bg-a: rgba(100, 222, 148, 0.46);
+  --color-grade-bg-b: rgba(255, 215, 95, 0.36);
+  --color-grade-bg-c: rgba(255, 165, 85, 0.28);
+  --color-grade-bg-d: rgba(255, 125, 105, 0.26);
+  --color-status-bg-pass: rgba(100, 222, 148, 0.16);
+  --color-status-bg-failed: rgba(255, 145, 135, 0.2);
   --color-status-bg-pending: rgba(160, 156, 144, 0.2);
   --color-status-pending: #a09c90;
   --color-status-failed: #ff7a6e;
@@ -162,8 +162,8 @@
     --color-disabled-bg: #2a2924;
     --color-table-head: #201f1b;
     --color-row-even: #201f1b;
-    --color-row-hover: rgba(147, 184, 220, 0.08);
-    --color-row-hover-solid: #292b2a;
+    --color-row-hover: rgba(147, 184, 220, 0.14);
+    --color-row-hover-solid: #333a42;
     --color-badge-bg: transparent;
     --color-button-focus: rgba(147, 184, 220, 0.22);
     --color-control-focus: rgba(147, 184, 220, 0.18);
@@ -194,16 +194,16 @@
     --color-card-codev3-primary-border: #4a473c;
     --color-card-codev3-secondary-bg: #26251f;
     --color-card-codev3-secondary-border: #403e35;
-    --color-grade-a: #7fb98f;
+    --color-grade-a: #e8f6ee;
     --color-grade-b: #e6bf4a;
     --color-grade-c: #f29a52;
     --color-grade-d: #f28e72;
-    --color-grade-bg-a: rgba(96, 196, 132, 0.26);
-    --color-grade-bg-b: rgba(255, 208, 80, 0.3);
-    --color-grade-bg-c: rgba(255, 148, 52, 0.3);
-    --color-grade-bg-d: rgba(255, 100, 55, 0.35);
-    --color-status-bg-pass: rgba(96, 196, 132, 0.26);
-    --color-status-bg-failed: rgba(255, 64, 64, 0.3);
+    --color-grade-bg-a: rgba(100, 222, 148, 0.46);
+    --color-grade-bg-b: rgba(255, 215, 95, 0.36);
+    --color-grade-bg-c: rgba(255, 165, 85, 0.28);
+    --color-grade-bg-d: rgba(255, 125, 105, 0.26);
+    --color-status-bg-pass: rgba(100, 222, 148, 0.16);
+    --color-status-bg-failed: rgba(255, 145, 135, 0.2);
     --color-status-bg-pending: rgba(160, 156, 144, 0.2);
     --color-status-pending: #a09c90;
     --color-status-failed: #ff7a6e;
@@ -431,7 +431,9 @@ main {
 }
 
 .dataset-meta.active {
-  display: block;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
 }
 
 .dataset-meta strong {
@@ -441,6 +443,13 @@ main {
 
 .dataset-meta span {
   margin-right: 18px;
+  color: var(--color-muted);
+}
+
+/* 右侧对齐的格式说明（代码 v3 数据集信息条最右侧） */
+.dataset-meta .meta-note {
+  margin-right: 0;
+  margin-left: auto;
   color: var(--color-muted);
 }
 
@@ -533,6 +542,18 @@ main {
 .table-container--codev3 th,
 .table-container--codev3 td {
   white-space: nowrap;
+}
+
+/* 档位色块单元格之间留出间隙（透明边框 + 背景裁剪，色块不粘连） */
+.table-container--codev3 th,
+.table-container--codev3 td {
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+/* 冻结列背景必须覆盖到边框区，否则横向滚动时下层内容会从间隙透出 */
+.table-container--codev3 .codev3-model-column {
+  background-clip: border-box;
 }
 
 .table-container--codev3 .codev3-model-column {
@@ -988,6 +1009,16 @@ main {
 .table-note .grade-chip--failed {
   color: var(--color-status-failed);
   background-color: var(--color-status-bg-failed);
+}
+
+.table-note .grade-chip--pass {
+  color: var(--color-grade-a);
+  background-color: var(--color-status-bg-pass);
+}
+
+.table-note .grade-chip--pending {
+  color: var(--color-status-pending);
+  background-color: var(--color-status-bg-pending);
 }
 
 .mobile-card-note {

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,6 +54,7 @@
           <div id="tableContainer" class="table-container">
             <div class="placeholder" role="status">请选择数据集开始浏览。</div>
           </div>
+          <section class="table-note" id="tableNote" hidden></section>
         </section>
 
         <section class="chart-section" id="chartSection" style="display: none;">


### PR DESCRIPTION
## 改动内容

代码 v3 榜单页面的视觉效果与说明优化：

- **档位/状态单元格底色**：A/B/C/D、Pass、Failed、Pending 整格底色区分，深浅代表成绩（越深越好，A 深绿 → B 金 → C 橙 → D 红 → Failed 浅红）
- **单元格间隙**：色块单元格之间 2px 空隙，卡片式观感
- **行悬停高亮加强**：hover 整行（含间隙）更明显
- **表格底部档位说明**：A/B/C/D/Failed/Pass/Pending 徽章图例 + 半档规则 + 2026-07 月榜方法说明（仅档位制数据集显示）
- **数据集信息条**：最右侧右对齐显示 `1/A 代表扣分数/档位` 格式说明
- 中英双语 i18n，浅色/深色主题自适应